### PR TITLE
docs: Update links to the renamed organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This guide is intended to help you get started with developing quizx.
 
-If you find any errors or omissions in this document, please [open an issue](https://github.com/Quantomatic/quizx/issues/new)!
+If you find any errors or omissions in this document, please [open an issue](https://github.com/zxlang/quizx/issues/new)!
 
 ## #️⃣ Setting up the development environment
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ version = "0.1.0"
 authors = ["Aleks Kissinger <aleks0@gmail.com>"]
 edition = "2021"
 rust-version = "1.75"
-homepage = "https://github.com/Quantomatic/quizx"
+homepage = "https://github.com/zxlang/quizx"
 license-file = "LICENSE"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QuiZX: a quick Rust port of PyZX
 
-[PyZX](https://github.com/Quantomatic/pyzx) is a Python library for quantum circuit optimisation and compiling using the [ZX-calculus](https://zxcalculus.com). It's great for hacking, learning, and trying things out in [Jupyter](https://jupyter.org/) notebooks. However, it's written to maximise clarity and fun, not performance.
+[PyZX](https://github.com/zxlang/pyzx) is a Python library for quantum circuit optimisation and compiling using the [ZX-calculus](https://zxcalculus.com). It's great for hacking, learning, and trying things out in [Jupyter](https://jupyter.org/) notebooks. However, it's written to maximise clarity and fun, not performance.
 
 This is a port of some of the core functionality of PyZX to the [Rust](https://www.rust-lang.org/) programming language. This is a modern systems programming language, which enables writing software that is very fast and memory efficient.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ requires-python = ">=3.10"
 license = { file = "LICENSE" }
 
 [project.urls]
-homepage = "https://github.com/Quantomatic/quizx"
-repository = "https://github.com/Quantomatic/quizx"
+homepage = "https://github.com/zxlang/quizx"
+repository = "https://github.com/zxlang/quizx"
 
 [tool.maturin]
 module-name = "quizx._quizx"

--- a/quizx/src/json.rs
+++ b/quizx/src/json.rs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Json encoding for interoperability with pyzx and Quantomatic using the .qgraph format.
+//! Json encoding for interoperability with pyzx and zxlang using the .qgraph format.
 //!
 //! # Examples
 //!
@@ -93,7 +93,7 @@ type VertexName = String;
 /// Identifier for an encoded edge.
 type EdgeName = String;
 
-/// The json-encoded format for pyzx and Quantomatic graphs.
+/// The json-encoded format for pyzx and zxlang graphs.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct JsonGraph {
     /// Wire vertices of the graph.

--- a/stabrank.md
+++ b/stabrank.md
@@ -4,11 +4,11 @@ The data from the paper "Simulating quantum circuits with ZX-calculus reduced st
 
 To reproduce, first grab a version of `quizx`. Either get the latest version with:
 
-    git clone https://github.com/Quantomatic/quizx.git
+    git clone https://github.com/zxlang/quizx.git
 
 or the exact version used in the paper with:
 
-    git clone --branch stabrank-v1 https://github.com/Quantomatic/quizx.git
+    git clone --branch stabrank-v1 https://github.com/zxlang/quizx.git
 
 
 In either case, build `quizx` via:


### PR DESCRIPTION
Renames references to "Quantomatic" to the new "zxlang" github organization.