### PR TITLE
fix: sdist build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a port of some of the core functionality of PyZX to the [Rust](https://www.rust-lang.org/) programming language. This is a modern systems programming language, which enables writing software that is very fast and memory efficient.
 
-See the [CONTRIBUTING.md](CONTRIBUTING.md) file for detailed instructions for building the libraries from source and contributing to the project.
+See the [CONTRIBUTING.md](https://github.com/zxcalc/quizx/blob/master/CONTRIBUTING.md) file for detailed instructions for building the libraries from source and contributing to the project.
 
 ## A bit about performance
 

--- a/pybindings/README.md
+++ b/pybindings/README.md
@@ -1,8 +1,33 @@
-This folder contains Python bindings for quizx so that it can be used with PyZX.
-To install, run the install_package.bat file (on Windows).
-Or you can install manually by calling::
+# QuiZX: A quick backend for PyZX
 
-    python setup.py install
-    python setup2.py install
+[PyZX](https://github.com/zxlang/pyzx) is a Python library for quantum circuit optimisation and compiling using the [ZX-calculus](https://zxcalculus.com). It's great for hacking, learning, and trying things out in [Jupyter](https://jupyter.org/) notebooks. However, it's written to maximise clarity and fun, not performance.
 
-The first installs a user-friendly Python interface over the raw Rust bindings. The second installs the actual quizx Python-Rust interface. For some reason the order in which you install these is important (you get a `ImportError: dynamic module does not define module export function` otherwise).
+This is a port of some of the core functionality of PyZX to the [Rust](https://www.rust-lang.org/) programming language. This is a modern systems programming language, which enables writing software that is very fast and memory efficient.
+
+See the [CONTRIBUTING.md](https://github.com/zxcalc/quizx/blob/master/CONTRIBUTING.md) file for detailed instructions for building the libraries from source and contributing to the project.
+
+## A bit about performance
+
+As a very anecdotal example of the performance difference, the program `spider_chain` builds a chain of 1 million green spiders and fuses them all. In PyZX, you can fuse all the spiders in a ZX-diagram as follows:
+
+```python
+from pyzx.basicrules import *
+
+success = True
+while success
+    success = any(fuse(g, g.edge_s(e), g.edge_t(e)) for e in g.edges()):
+```
+
+In QuiZX, the Rust code is slightly more verbose, but similar in spirit:
+```rust
+use quizx::basic_rules::*;
+
+loop {
+    match g.find_edge(|v0,v1,_| check_spider_fusion(&g, v0, v1)) {
+        Some((v0,v1,_)) => spider_fusion_unsafe(&mut g, v0, v1),
+        None => break,
+    };
+}
+```
+
+On my laptop, the PyZX code takes about 98 seconds to fuse 1 million spiders, whereas the QuiZX code takes 17 milliseconds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "quizx"
+description = "Quantum Circuit Optimisation and Compilation using the ZX-calculus"
 version = "0.1.0"
 requires-python = ">=3.9,<3.14"
-description = "Quantum Circuit Optimisation and Compilation using the ZX-calculus"
 license = { file = "LICENSE" }
-readme = "README.md"
+readme = "pybindings/README.md"
 authors = [{ name = "Aleks Kissinger", email = "aleks0@gmail.com" }]
 maintainers = [
     { name = "Aleks Kissinger", email = "aleks0@gmail.com" },

--- a/quizx/Cargo.toml
+++ b/quizx/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "quizx"
+description = "Quantum Circuit Optimisation and Compilation using the ZX-calculus"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
Building the source wheels failed due duplicated READMEs.

https://github.com/zxcalc/quizx/actions/runs/11141837093/job/30963545762#step:3:190

This PR writes a better readme for the python package in `pybindings/`, and avoids including the one at the project root.