### PR TITLE
ci: Fix disabled pr-title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ name: Check Conventional Commits format
 on:
   pull_request_target:
     branches:
-      - main
+      - master
     types:
       - opened
       - edited


### PR DESCRIPTION
The check that validates a PR's title was enabled for "main" instead of "master"