### PR TITLE
ci: Try to debug the release workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,9 +31,16 @@ jobs:
       - name: Check tag
         id: check-tag
         run: |
+          echo "Should run on this event: $SHOULD_RUN"
+          echo "Making release: $MAKING_RELEASE"
+          echo "Event name: ${{ github.event_name }}"
+          echo "Ref type: ${{ github.ref_type }}"
+          echo "Ref: ${{ github.ref }}"
+
           echo "run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         env:
           SHOULD_RUN: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/quizx-py-v') ) }}
+          MAKING_RELEASE: ${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/quizx-py-v') && (github.event_name == 'release'  || github.event_name == 'workflow_dispatch' ) }}
 
   linux:
     needs: check-tag
@@ -184,7 +191,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/quizx-py-v') ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/quizx-py-v') ) }}
+    if: ${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/quizx-py-v') && (github.event_name == 'release'  || github.event_name == 'workflow_dispatch' ) }}
     needs: [linux, musllinux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
The release workflow ran and built the wheels, but for some reason the `publish` step got skipped -.-'
https://github.com/zxcalc/quizx/actions/runs/11603200919/job/32310138857

This PR simplifies the `if` condition and adds debug info.