### PR TITLE
ci(wheels): Update x86 macos builder to macos-13

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
           - runner: macos-14
             target: aarch64


### PR DESCRIPTION
`macos-12` workers got deprecated, so the wheel building job hangs forever waiting for a worker.