### PR TITLE
ci: Setup crate releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,64 @@
+# Automatic changelog, version bumping, and semver-checks with release-plz for rust projects
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release unpublished packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  #
+  # Note: When using the default `secrets.GITHUB_TOKEN` provided by GitHub Actions, the created PR
+  # will not trigger CI checks due to a limitation on recursive workflows.
+  # We could use a personal access token (PAT) instead, but we should create a bot account for that
+  # (otherwise PRs will be created in whoever's account provided the token).
+  release-plz-pr:
+    name: Generate release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,153 @@
+name: Rust semver-checks
+
+on:
+    pull_request_target:
+        branches:
+            - master
+        types:
+            - opened
+            - edited
+            - synchronize
+            - reopened
+    workflow_dispatch:
+        inputs:
+            base:
+                description: 'Base branch or tag to run the semver checks against.'
+                required: true
+                default: 'master'
+
+env:
+  CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  semver-checks:
+    name: semver-checks 🦀
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          path: PR_BRANCH
+      - name: Checkout baseline
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.event.inputs.base }}
+          path: BASELINE_BRANCH
+      - uses: mozilla-actions/sccache-action@v0.0.8
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # Install a prebuilt binary of cargo-semver-checks
+      - uses: cargo-bins/cargo-binstall@main
+      - name: Install cargo-semver-checks
+        run: cargo binstall -y cargo-semver-checks
+
+      # Abort if the crate has build errors, without posting/deleting the comment.
+      - name: Check for build errors
+        id: build
+        run: |
+            cd PR_BRANCH
+            cargo check
+
+      # Run cargo-semver-checks against the PR's target branch.
+      - name: Check for public API changes
+        id: check-changes
+        run: |
+          # Don't fail the workflow when semver-checks returns a non-zero exit code.
+          set +e
+
+          cd PR_BRANCH
+          cargo semver-checks --color never --baseline-root ../BASELINE_BRANCH --release-type minor > diagnostic.txt
+          if [ "$?" -ne 0 ]; then
+            echo "breaking=true" >> $GITHUB_OUTPUT
+          else
+            echo "breaking=false" >> $GITHUB_OUTPUT
+          fi
+
+          {
+            echo 'semver_checks_diagnostic<<EOF'
+            cat diagnostic.txt
+            echo
+            echo EOF
+          } >> $GITHUB_OUTPUT
+
+          echo "semver-checks diagnostic:\n"
+          cat diagnostic.txt
+      
+      # Check if the PR title contains a breaking change flag in its title,
+      # according to the conventional commits specification.
+      #
+      # When the PR is flagged as breaking we only post an informative comment
+      # instead of failing the workflow.
+      - name: Check for breaking change flag
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+        id: breaking-pr
+        run: |
+          if [[ "${PR_TITLE}" =~ ^.*\!:.*$ ]]; then
+            echo "breaking=true" >> $GITHUB_OUTPUT
+          else
+            echo "breaking=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+
+      # Debug step
+      - run: |
+          echo "breaking: ${{ steps.check-changes.outputs.breaking }}"
+          echo "breaking-pr: ${{ steps.breaking-pr.outputs.breaking }}"
+
+      # Post a diagnostics comment if there are breaking changes and the PR has been marked as breaking.
+      - name: Post a comment about the breaking changes. PR marked as breaking.
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'true' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: rs-semver-checks
+          message: |
+            This PR contains breaking changes to the public Rust API.
+
+            <details>
+              <summary>cargo-semver-checks summary</summary>
+              
+              ```
+              ${{ steps.check-changes.outputs.semver_checks_diagnostic }}
+              ```
+              
+            </details>
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+
+      # Post a help comment if there are breaking changes, and the PR hasn't been marked as breaking.
+      - name: Post a comment about the breaking changes. PR *not* marked as breaking.
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'false' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: rs-semver-checks
+          message: |
+            This PR contains breaking changes to the public Rust API.
+            Please deprecate the old API instead (if possible), or mark the PR with a `!` following the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format to indicate a breaking change.
+
+            <details>
+              <summary>cargo-semver-checks summary</summary>
+              
+              ```
+              ${{ steps.check-changes.outputs.semver_checks_diagnostic }}
+              ```
+              
+            </details>
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+      - name: Fail if there are undeclared breaking changes
+        if: ${{ steps.check-changes.outputs.breaking == 'true' && steps.breaking-pr.outputs.breaking == 'false' }}
+        run: exit 1
+
+      # Delete previous comments when the issues have been resolved
+      # This step doesn't run if any of the previous checks fails.
+      - name: Delete previous comments
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.check-changes.outputs.breaking == 'false' }}
+        with:
+          header: rs-semver-checks
+          delete: true
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,61 @@
+# Automatic changelog generation for rust projects
+
+[workspace]
+# Disable processing the packages by default
+release = false
+
+# Open the release PR as a draft
+pr_draft = true
+
+# Enforce adding the project name in the git tag, to avoid collisions with python.
+# (This would normally only be enabled once there are multiple packages in the workspace)
+git_tag_name = "{{ package }}@v{{ version }}"
+git_release_name = "{{ package }}: v{{ version }}"
+
+# Only create releases / push to crates.io after merging a release-please PR.
+# This lets merge new crates to `main` without worrying about accidentally creating
+# github releases.
+#
+# To trigger a release manually, merge a PR from a branch starting with `release-plz-`.
+release_always = false
+
+# Include a list of contributors in the release body
+git_release_body = """
+{{ changelog }}
+{% if remote.contributors %}
+### Contributors
+{% for contributor in remote.contributors %}
+* @{{ contributor.username }}
+{% endfor %}
+{% endif %}
+"""
+
+[changelog]
+sort_commits = "oldest"
+protect_breaking_commits = true
+
+header = """# Changelog
+
+This is the changelog for the `quizx` rust library.
+For the changelog of the `quizx` python library, see the separate [`CHANGELOG.md`](https://github.com/zxcalc/quizx/blob/master/pybindings/CHANGELOG.md) file.
+
+"""
+
+# Allowed conventional commit types
+commit_parsers = [
+    { message = "^feat", group = "New Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^style", group = "Styling" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^perf", group = "Performance" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous Tasks", skip = true },
+    { message = "^revert", group = "Reverted changes", skip = true },
+    { message = "^ci", group = "CI", skip = true },
+]
+
+[[package]]
+name = "quizx"
+release = true
+git_release_latest = true


### PR DESCRIPTION
Sets up `release-plz` to auto-generate release PRs with changelog and crate version updates (similar to the python ones).
Once one of those PRs gets merged, it will automatically generate a new github release for the crate and upload it to crates.io.

I also added a workflow that runs `cargo-semver-checks`, so it detects when the changes in a PR break semver compatibility and we should mark it as such (by adding a `!` in the PR title). These `!`s will be detected by `release-plz` when choosing the next crate version.

I haven't added a crates io api token yet. Tokens can be given permissions to publish new crates and to publish crate-updates separatedly. To avoid any surprises, I prefer to only give automation the latter, so I'll do the first release `0.1.0` manually instead.