### PR TITLE
ci: mark the release PRs as either rust of python

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,67 +1,67 @@
 {
-    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-    "include-component-in-tag": true,
-    "bump-minor-pre-major": true,
-    "bump-patch-for-minor-pre-major": true,
-    "initial-version": "0.0.0",
-    "separate-pull-requests": true,
-    "pull-request-title-pattern": "chore(py): release${component} ${version}",
-    "packages": {
-        "pybindings": {
-            "release-type": "python",
-            "component": "quizx-py",
-            "package-name": "quizx",
-            "include-component-in-tag": true,
-            "draft": false,
-            "prerelease": false,
-            "draft-pull-request": true
-        }
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "initial-version": "0.0.0",
+  "separate-pull-requests": true,
+  "pull-request-title-pattern": "chore(🐍): release${component} ${version}",
+  "packages": {
+    "pybindings": {
+      "release-type": "python",
+      "component": "quizx-py",
+      "package-name": "quizx",
+      "include-component-in-tag": true,
+      "draft": false,
+      "prerelease": false,
+      "draft-pull-request": true
+    }
+  },
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
     },
-    "changelog-sections": [
-        {
-            "type": "feat",
-            "section": "Features"
-        },
-        {
-            "type": "fix",
-            "section": "Bug Fixes"
-        },
-        {
-            "type": "perf",
-            "section": "Performance Improvements"
-        },
-        {
-            "type": "revert",
-            "section": "Reverts"
-        },
-        {
-            "type": "docs",
-            "section": "Documentation"
-        },
-        {
-            "type": "style",
-            "section": "Styling",
-            "hidden": true
-        },
-        {
-            "type": "chore",
-            "section": "Miscellaneous Chores",
-            "hidden": true
-        },
-        {
-            "type": "refactor",
-            "section": "Code Refactoring",
-            "hidden": true
-        },
-        {
-            "type": "test",
-            "section": "Tests",
-            "hidden": true
-        },
-        {
-            "type": "ci",
-            "section": "Continuous Integration",
-            "hidden": true
-        }
-    ]
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "style",
+      "section": "Styling",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
+  ]
 }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,6 +6,7 @@ release = false
 
 # Open the release PR as a draft
 pr_draft = true
+pr_name = "chore(🦀): release {{ package }} {{ version }}"
 
 # Enforce adding the project name in the git tag, to avoid collisions with python.
 # (This would normally only be enabled once there are multiple packages in the workspace)


### PR DESCRIPTION
Gives a clear distinction between both release PRs by adding a 🦀 or 🐍 tag to their title

drive-by: format the release-please yml