### PR TITLE
feat!: converting a circuit to a graph while performing Clifford simplifications

### DIFF
--- a/quizx/examples/surface_code.rs
+++ b/quizx/examples/surface_code.rs
@@ -33,7 +33,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     interior_clifford_simp(&mut g);
     println!("Done in {:?}", time.elapsed());
 
-    println!("Result has {} vertices", g.num_vertices());
+    println!(
+        "Result has {} vertices, {} inputs, {} outputs",
+        g.num_vertices(),
+        g.inputs().len(),
+        g.outputs().len()
+    );
 
     let factors: Vec<Expr> = g
         .scalar_factors()

--- a/quizx/examples/surface_code.rs
+++ b/quizx/examples/surface_code.rs
@@ -9,7 +9,7 @@ use quizx::{graph::*, vec_graph::Graph};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let distance = 50;
-    let rounds = 50;
+    let rounds = 100;
     let time = Instant::now();
     println!(
         "Building surface code circuit with distance {} and {} rounds...",
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let time = Instant::now();
     println!("Converting to graph...");
-    let mut g: Graph = c.to_graph();
+    let mut g: Graph = c.to_graph_with_options(false, false);
     println!("Done in {:?}", time.elapsed());
 
     println!("Initial ZX diagram has {} vertices", g.num_vertices());

--- a/quizx/examples/surface_code.rs
+++ b/quizx/examples/surface_code.rs
@@ -9,7 +9,7 @@ use quizx::{graph::*, vec_graph::Graph};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let distance = 50;
-    let rounds = 100;
+    let rounds = 50;
     let time = Instant::now();
     println!(
         "Building surface code circuit with distance {} and {} rounds...",

--- a/quizx/src/basic_rules.rs
+++ b/quizx/src/basic_rules.rs
@@ -527,6 +527,15 @@ fn is_boundary_pauli(g: &impl GraphLike, v: V) -> bool {
     g.phase(v).is_pauli() && g.neighbors(v).any(|n| g.vertex_type(n) == VType::B)
 }
 
+// check that a vertex is on a boundary, has phase 0 or pi, and is not
+// a phase gadget
+#[inline]
+fn is_boundary_pauli_with_h(g: &impl GraphLike, v: V) -> bool {
+    g.phase(v).is_pauli()
+        && g.incident_edges(v)
+            .any(|(n, et)| et == EType::H && g.vertex_type(n) == VType::B)
+}
+
 // check that a vertex is on a boundary, has phase -pi/2 or pi/2, and is not
 // a phase gadget
 #[inline]
@@ -547,6 +556,11 @@ pub fn check_gen_pivot_reduce(g: &impl GraphLike, v0: V, v1: V) -> bool {
 #[inline]
 pub fn check_boundary_pivot(g: &impl GraphLike, v0: V, v1: V) -> bool {
     check_gen_pivot(g, v0, v1) && is_boundary_pauli(g, v0)
+}
+
+#[inline]
+pub fn check_h_boundary_pivot(g: &impl GraphLike, v0: V, v1: V) -> bool {
+    check_gen_pivot(g, v0, v1) && is_boundary_pauli_with_h(g, v0)
 }
 
 /// Generic version of the pivot rule
@@ -581,6 +595,11 @@ pub fn gen_pivot_unchecked(g: &mut impl GraphLike, v0: V, v1: V) {
 
 checked_rule2!(check_gen_pivot, gen_pivot_unchecked, gen_pivot);
 checked_rule2!(check_boundary_pivot, gen_pivot_unchecked, boundary_pivot);
+checked_rule2!(
+    check_h_boundary_pivot,
+    gen_pivot_unchecked,
+    h_boundary_pivot
+);
 
 #[inline]
 pub fn check_boundary_local_comp(g: &impl GraphLike, v0: V, v1: V) -> bool {

--- a/quizx/src/basic_rules.rs
+++ b/quizx/src/basic_rules.rs
@@ -520,11 +520,18 @@ fn is_interior_pauli(g: &impl GraphLike, v: V) -> bool {
             .all(|n| g.vertex_type(n) == VType::Z && g.degree(n) > 1)
 }
 
-// check that a vertex is interior, has phase 0 or pi, and is not
+// check that a vertex is on a boundary, has phase 0 or pi, and is not
 // a phase gadget
 #[inline]
 fn is_boundary_pauli(g: &impl GraphLike, v: V) -> bool {
     g.phase(v).is_pauli() && g.neighbors(v).any(|n| g.vertex_type(n) == VType::B)
+}
+
+// check that a vertex is on a boundary, has phase -pi/2 or pi/2, and is not
+// a phase gadget
+#[inline]
+fn is_boundary_proper_clifford(g: &impl GraphLike, v: V) -> bool {
+    g.phase(v).is_proper_clifford() && g.neighbors(v).any(|n| g.vertex_type(n) == VType::B)
 }
 
 /// Check gen_pivot applies and at least one vertex is interior Pauli
@@ -574,6 +581,30 @@ pub fn gen_pivot_unchecked(g: &mut impl GraphLike, v0: V, v1: V) {
 
 checked_rule2!(check_gen_pivot, gen_pivot_unchecked, gen_pivot);
 checked_rule2!(check_boundary_pivot, gen_pivot_unchecked, boundary_pivot);
+
+#[inline]
+pub fn check_boundary_local_comp(g: &impl GraphLike, v0: V, v1: V) -> bool {
+    v0 != v1
+        && g.edge_type_opt(v0, v1) != Some(EType::H)
+        && is_boundary_proper_clifford(g, v0)
+        && is_interior_pauli(g, v1)
+}
+
+#[inline]
+pub fn boundary_local_comp_unchecked(g: &mut impl GraphLike, v0: V, v1: V) {
+    for b in g.neighbor_vec(v0) {
+        unfuse_boundary(g, v0, b);
+    }
+
+    local_comp_unchecked(g, v0);
+    local_comp_unchecked(g, v1);
+}
+
+checked_rule2!(
+    check_boundary_local_comp,
+    boundary_local_comp_unchecked,
+    boundary_local_comp
+);
 
 #[inline]
 pub fn check_gadget_fusion(g: &impl GraphLike, v0: V, v1: V) -> bool {

--- a/quizx/src/circuit.rs
+++ b/quizx/src/circuit.rs
@@ -20,7 +20,7 @@ use crate::linalg::RowOps;
 use crate::params::Parity;
 use crate::params::Var;
 use crate::phase::Phase;
-use crate::simplify::local_clifford_simp;
+use crate::simplify::local_ap_simp;
 use crate::util::pmax;
 use num::{Rational64, Zero};
 use openqasm::{ast::Symbol, translate::Value, GenericError, ProgramVisitor};
@@ -304,7 +304,7 @@ impl Circuit {
             let vs = g.add_to_graph(&mut fresh_var, &mut graph, &mut qs, postselect);
 
             if simplify {
-                local_clifford_simp(&mut graph, vs);
+                local_ap_simp(&mut graph, vs);
             }
         }
 

--- a/quizx/src/circuit.rs
+++ b/quizx/src/circuit.rs
@@ -20,8 +20,10 @@ use crate::linalg::RowOps;
 use crate::params::Parity;
 use crate::params::Var;
 use crate::phase::Phase;
+use crate::util::pmax;
 use num::{Rational64, Zero};
 use openqasm::{ast::Symbol, translate::Value, GenericError, ProgramVisitor};
+use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::fmt;
 use std::str;
@@ -262,23 +264,33 @@ impl Circuit {
 
     pub fn to_graph_with_options<G: GraphLike>(&self, postselect: bool) -> G {
         let mut graph = G::new();
-        let mut qs = Vec::with_capacity(self.nqubits);
+        let mut qs = FxHashMap::default();
         let mut inputs = Vec::with_capacity(self.nqubits);
+        let mut outputs = Vec::with_capacity(self.nqubits);
 
         // we start counting rows from 1, to allow coordinate
         // (0,0) to mean "no coordinate"
         for i in 0..self.nqubits {
-            let v = graph.add_vertex_with_data(VData {
+            let inp = graph.add_vertex_with_data(VData {
                 ty: VType::B,
                 qubit: i as f64,
                 row: 1.0,
                 ..Default::default()
             });
-            qs.push(Some(v));
-            inputs.push(v);
+            let outp = graph.add_vertex_with_data(VData {
+                ty: VType::B,
+                qubit: i as f64,
+                row: 2.0,
+                ..Default::default()
+            });
+            graph.add_edge(inp, outp);
+            inputs.push(inp);
+            outputs.push(outp);
+            qs.insert(i, i);
         }
 
         graph.set_inputs(inputs);
+        graph.set_outputs(outputs);
 
         let mut fresh_var: Var = self
             .gates
@@ -291,31 +303,12 @@ impl Circuit {
             g.add_to_graph(&mut fresh_var, &mut graph, &mut qs, postselect);
         }
 
-        let last_row = qs
-            .iter()
-            .fold(None, |r, &v| match (r, v.map(|v1| graph.row(v1))) {
-                (Some(r), Some(r1)) => Some(if r < r1 { r1 } else { r }),
-                (Some(r), None) => Some(r),
-                (None, Some(r1)) => Some(r1),
-                (None, None) => None,
-            })
-            .unwrap_or(0.0);
+        let last_row = pmax(graph.outputs().iter().map(|&o| graph.row(o))).unwrap_or(2.0);
 
-        let mut outputs = Vec::with_capacity(self.nqubits);
-        for (i, &q) in qs.iter().enumerate() {
-            if let Some(v0) = q {
-                let v = graph.add_vertex_with_data(VData {
-                    ty: VType::B,
-                    qubit: i as f64,
-                    row: last_row + 1.0,
-                    ..Default::default()
-                });
-                graph.add_edge(v0, v);
-                outputs.push(v);
-            }
+        for outp in graph.outputs().clone() {
+            graph.set_row(outp, last_row);
         }
 
-        graph.set_outputs(outputs);
         graph
     }
 

--- a/quizx/src/gate.rs
+++ b/quizx/src/gate.rs
@@ -452,7 +452,13 @@ impl Gate {
                 );
             }
             HAD => {
-                Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::H, Phase::zero());
+                if let Some(&i) = qs.get(&self.qs[0]) {
+                    let outp = graph.outputs()[i];
+                    let v_opt = graph.neighbors(outp).next();
+                    if let Some(v) = v_opt {
+                        graph.toggle_edge_type(outp, v);
+                    }
+                }
             }
             CNOT => {
                 if let (Some(v1), Some(v2)) = (
@@ -518,7 +524,8 @@ impl Gate {
                 }
             }
             InitAncilla => {
-                if let Some(&outp) = qs.get(&self.qs[0]) {
+                if let Some(&i) = qs.get(&self.qs[0]) {
+                    let outp = graph.outputs()[i];
                     let inp_opt = graph.neighbors(outp).next();
                     if let Some(inp) = inp_opt {
                         if graph.vertex_type(inp) == VType::B {

--- a/quizx/src/gate.rs
+++ b/quizx/src/gate.rs
@@ -457,16 +457,9 @@ impl Gate {
             )
             .into_iter()
             .collect(),
-            HAD => {
-                if let Some(&i) = qs.get(&self.qs[0]) {
-                    let outp = graph.outputs()[i];
-                    let v_opt = graph.neighbors(outp).next();
-                    if let Some(v) = v_opt {
-                        graph.toggle_edge_type(outp, v);
-                    }
-                }
-                vec![]
-            }
+            HAD => Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::H, Phase::zero())
+                .into_iter()
+                .collect(),
             CNOT => {
                 if let (Some(v1), Some(v2)) = (
                     Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::N, Phase::zero()),

--- a/quizx/src/gate.rs
+++ b/quizx/src/gate.rs
@@ -459,11 +459,15 @@ impl Gate {
                     Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::N, Phase::zero()),
                     Gate::add_spider(graph, qs, self.qs[1], VType::X, EType::N, Phase::zero()),
                 ) {
-                    let r1 = graph.row(v1);
-                    let r2 = graph.row(v2);
+                    let o1 = graph.outputs()[*qs.get(&self.qs[0]).unwrap()];
+                    let o2 = graph.outputs()[*qs.get(&self.qs[1]).unwrap()];
+                    let r1 = graph.row(o1);
+                    let r2 = graph.row(o2);
                     let row = if r1 < r2 { r2 } else { r1 };
-                    graph.set_row(v1, row);
-                    graph.set_row(v2, row);
+                    graph.set_row(v1, row - 1.0);
+                    graph.set_row(v2, row - 1.0);
+                    graph.set_row(o1, row);
+                    graph.set_row(o2, row);
 
                     graph.add_edge(v1, v2);
                     graph.scalar_mut().mul_sqrt2_pow(1);
@@ -474,11 +478,15 @@ impl Gate {
                     Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::N, Phase::zero()),
                     Gate::add_spider(graph, qs, self.qs[1], VType::Z, EType::N, Phase::zero()),
                 ) {
-                    let r1 = graph.row(v1);
-                    let r2 = graph.row(v2);
+                    let o1 = graph.outputs()[*qs.get(&self.qs[0]).unwrap()];
+                    let o2 = graph.outputs()[*qs.get(&self.qs[1]).unwrap()];
+                    let r1 = graph.row(o1);
+                    let r2 = graph.row(o2);
                     let row = if r1 < r2 { r2 } else { r1 };
-                    graph.set_row(v1, row);
-                    graph.set_row(v2, row);
+                    graph.set_row(v1, row - 1.0);
+                    graph.set_row(v2, row - 1.0);
+                    graph.set_row(o1, row);
+                    graph.set_row(o2, row);
 
                     graph.add_edge_with_type(v1, v2, EType::H);
                     graph.scalar_mut().mul_sqrt2_pow(1);
@@ -489,11 +497,15 @@ impl Gate {
                     Gate::add_spider(graph, qs, self.qs[0], VType::X, EType::N, Phase::zero()),
                     Gate::add_spider(graph, qs, self.qs[1], VType::X, EType::N, Phase::zero()),
                 ) {
-                    let r1 = graph.row(v1);
-                    let r2 = graph.row(v2);
+                    let o1 = graph.outputs()[*qs.get(&self.qs[0]).unwrap()];
+                    let o2 = graph.outputs()[*qs.get(&self.qs[1]).unwrap()];
+                    let r1 = graph.row(o1);
+                    let r2 = graph.row(o2);
                     let row = if r1 < r2 { r2 } else { r1 };
-                    graph.set_row(v1, row);
-                    graph.set_row(v2, row);
+                    graph.set_row(v1, row - 1.0);
+                    graph.set_row(v2, row - 1.0);
+                    graph.set_row(o1, row);
+                    graph.set_row(o2, row);
 
                     graph.add_edge_with_type(v1, v2, EType::H);
                     graph.scalar_mut().mul_sqrt2_pow(1);
@@ -532,11 +544,11 @@ impl Gate {
 
                         // all later gates involving this qubit are quietly ignored
                         graph.outputs_mut().remove(i);
-                        qs.remove(&i);
+                        qs.remove(&self.qs[0]);
 
                         // adjust qubit indices to account for the missing output
-                        for (&k, v1) in qs.iter_mut() {
-                            if k > i {
+                        for (_, v1) in qs.iter_mut() {
+                            if *v1 > i {
                                 *v1 -= 1;
                             }
                         }
@@ -561,11 +573,11 @@ impl Gate {
 
                         // all later gates involving this qubit are quietly ignored
                         graph.outputs_mut().remove(i);
-                        qs.remove(&i);
+                        qs.remove(&self.qs[0]);
 
                         // adjust qubit indices to account for the missing output
-                        for (&k, v1) in qs.iter_mut() {
-                            if k > i {
+                        for (_, v1) in qs.iter_mut() {
+                            if *v1 > i {
                                 *v1 -= 1;
                             }
                         }

--- a/quizx/src/simplify.rs
+++ b/quizx/src/simplify.rs
@@ -160,8 +160,8 @@ pub fn flow_simp(g: &mut impl GraphLike) -> bool {
 }
 
 /// This takes an iterable collection of vertices on the boundary and tries to apply Clifford
-/// simplifications locally to remove them
-pub fn local_clifford_simp(g: &mut impl GraphLike, vs: impl IntoIterator<Item = V>) {
+/// simplifications locally to return to GSLC form
+pub fn local_gslc_simp(g: &mut impl GraphLike, vs: impl IntoIterator<Item = V>) {
     let mut simp_v = vec![];
     for v in vs {
         if let Some(vt) = g.vertex_type_opt(v) {
@@ -182,6 +182,35 @@ pub fn local_clifford_simp(g: &mut impl GraphLike, vs: impl IntoIterator<Item = 
                 || pivot(g, v, u)
                 || boundary_pivot(g, v, u)
                 || boundary_local_comp(g, v, u)
+            {
+                break;
+            }
+        }
+    }
+}
+
+/// This takes an iterable collection of vertices on the boundary and tries to apply Clifford
+/// simplifications locally to return to AP form
+pub fn local_ap_simp(g: &mut impl GraphLike, vs: impl IntoIterator<Item = V>) {
+    let mut simp_v = vec![];
+    for v in vs {
+        if let Some(vt) = g.vertex_type_opt(v) {
+            if vt == VType::X {
+                color_change(g, v);
+            } else if vt != VType::Z {
+                continue;
+            }
+
+            simp_v.push(v);
+        }
+    }
+
+    for v in simp_v {
+        for u in g.neighbor_vec(v) {
+            if spider_fusion(g, v, u)
+                || local_comp(g, u)
+                || pivot(g, v, u)
+                || h_boundary_pivot(g, v, u)
             {
                 break;
             }

--- a/quizx/src/simplify.rs
+++ b/quizx/src/simplify.rs
@@ -179,6 +179,7 @@ pub fn local_clifford_simp(g: &mut impl GraphLike, vs: impl IntoIterator<Item = 
         for u in g.neighbor_vec(v) {
             if spider_fusion(g, v, u)
                 || local_comp(g, u)
+                || pivot(g, v, u)
                 || boundary_pivot(g, v, u)
                 || boundary_local_comp(g, v, u)
             {

--- a/quizx/src/simplify.rs
+++ b/quizx/src/simplify.rs
@@ -19,6 +19,7 @@ use crate::graph::*;
 use crate::phase::Phase;
 use num::{One, Zero};
 use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 /// Repeatedly apply the given rule at any vertex
 /// that matches the check function
@@ -157,6 +158,26 @@ pub fn flow_simp(g: &mut impl GraphLike) -> bool {
     }
 
     got_match
+}
+
+pub fn clifford_simp_at(g: &mut impl GraphLike, vs: impl IntoIterator<Item = V>) {
+    let mut focus = FxHashSet::default();
+
+    for v in vs {
+        if g.vertex_type(v) == VType::X {
+            color_change(g, v);
+        }
+        focus.insert(v);
+        for (u, et) in g.incident_edge_vec(v) {
+            if et == EType::N && g.vertex_type(u) == VType::Z {
+                spider_fusion_unchecked(g, v, u)
+            } else if g.vertex_type(u) != VType::B {
+                focus.insert(u);
+            }
+        }
+    }
+
+    // TODO: this is WiP
 }
 
 pub fn interior_clifford_simp(g: &mut impl GraphLike) -> bool {


### PR DESCRIPTION
Added new simplifications `local_gslc_simp` and `local_ap_simp`, which each take a set of nodes and perform simplifications local to those nodes to try to preserve GSLC or AP normal forms, respectively.

The AP form reduction method can be called on-the-fly while generating a graph via `Circuit::to_graph_with_options` with `simplify=true`. This may perform better for some circuits then generating the whole graph at once and applying `clifford_simp`.

BREAKING CHANGE:

* `Circuit::to_graph_with_options` now takes an extra argument `simplify`. Set this to `false` to get the previous behavior.