### PR TITLE
feat!: better equality checker

### DIFF
--- a/quizx/src/equality.rs
+++ b/quizx/src/equality.rs
@@ -56,7 +56,7 @@ pub fn equal_graph_with_options(g1: &Graph, g2: &Graph, up_to_global_phase: bool
 
 /// Verifies the equality of two graphs up to global phase.
 pub fn equal_graph(g1: &Graph, g2: &Graph) -> Option<bool> {
-    equal_graph_with_options(&g1, &g2, true)
+    equal_graph_with_options(g1, g2, true)
 }
 
 /// Verifies the equality of two circuits.

--- a/quizx/src/equality.rs
+++ b/quizx/src/equality.rs
@@ -7,60 +7,80 @@ use crate::simplify::full_simp;
 use crate::tensor::ToTensor;
 use crate::vec_graph::Graph;
 
+/// Checks the equality of two circuit graphs by comparing the linear maps they represent.
+/// This approach is only feasible for a small number of qubits. (up to 6)
+pub fn equal_graph_tensor(g1: &Graph, g2: &Graph) -> bool {
+    g1.to_tensorf() == g2.to_tensorf()
+}
+
 /// Checks the equality of two circuits by comparing the linear maps they represent.
-/// This approach is only feasible for a small number of qubits.
-pub fn compare_tensors(c1: &Circuit, c2: &Circuit) -> bool {
-    c1.to_tensorf() == c2.to_tensorf()
+/// This approach is only feasible for a small number of qubits. (up to 6)
+pub fn equal_circuit_tensor(c1: &Circuit, c2: &Circuit) -> bool {
+    let g1: Graph = c1.to_graph();
+    let g2: Graph = c2.to_graph();
+    equal_graph_tensor(&g1, &g2)
 }
 
 /// Implements `Circuit.verify_equality` from pyzx.
 ///
-/// Verifies the equality of two circuits by investigating whether they "cancel each other out".
-/// This is done by composing one circuit with the adjoint of the other. If simplifying the
-/// result yields the identity, then the two circuits are verifiably equal.
+/// Verifies the equality of two circuit graphs by investigating whether they "cancel each other out".
+/// This is done by composing one circuit graph with the adjoint of the other. If simplifying the
+/// result yields the identity, then the two circuit graphs are verifiably equal.
 ///
-/// Note that the simplification may not yield the identity even if both circuits are equal,
+/// Note that the simplification may not yield the identity even if both circuit graphs are equal,
 /// which is why this approch gives an inconclusive answer if the resulting circuit is not
 /// the identity. In general, this approach can't verify that two circuits are unequal.
 ///
-/// This approach is feasible for a high number of qubits.
-pub fn verify_equality_with_options(
-    c1: &Circuit,
-    c2: &Circuit,
-    up_to_global_phase: bool,
-) -> Option<bool> {
-    if c1.num_qubits() != c2.num_qubits() {
-        // both circuits are verifiably unequal due to an unequal number of qubits
+/// This approach is feasible even for a high number of qubits.
+pub fn equal_graph_with_options(g1: &Graph, g2: &Graph, up_to_global_phase: bool) -> Option<bool> {
+    if g1.inputs().len() != g2.inputs().len() || g1.outputs().len() != g2.outputs().len() {
+        // both graphs are verifiably unequal due to an unequal number of (non-ancillae) qubits
         return Some(false);
     }
-    let c = c1.to_adjoint() + c2;
-    let mut g: Graph = c.to_graph();
+    let mut g = g1.to_adjoint();
+    g.plug(g2);
     full_simp(&mut g);
     if g.is_identity() {
         if !up_to_global_phase {
-            // both circuits are verifiably equal if the resulting global phase is zero
+            // both graphs are verifiably equal if the resulting global phase is zero
             // otherwise, they are verifiably unequal / only equal up to global phase
             let c: Complex<f64> = g.scalar().into();
             return Some(abs_diff_eq!(c.arg(), 0.0));
         }
-        // both circuits are verifiably equal up to global phase
+        // both graphs are verifiably equal up to global phase
         return Some(true);
     }
-    // both circuits are neither verifiably equal nor verifiably unequal
+    // both graphs are neither verifiably equal nor verifiably unequal
     None
 }
 
+/// Verifies the equality of two graphs up to global phase.
+pub fn equal_graph(g1: &Graph, g2: &Graph) -> Option<bool> {
+    equal_graph_with_options(&g1, &g2, true)
+}
+
+/// Verifies the equality of two circuits.
+pub fn equal_circuit_with_options(
+    c1: &Circuit,
+    c2: &Circuit,
+    up_to_global_phase: bool,
+) -> Option<bool> {
+    let g1: Graph = c1.to_graph();
+    let g2: Graph = c2.to_graph();
+    equal_graph_with_options(&g1, &g2, up_to_global_phase)
+}
+
 /// Verifies the equality of two circuits up to global phase.
-pub fn verify_equality(c1: &Circuit, c2: &Circuit) -> Option<bool> {
-    verify_equality_with_options(c1, c2, true)
+pub fn equal_circuit(c1: &Circuit, c2: &Circuit) -> Option<bool> {
+    equal_circuit_with_options(c1, c2, true)
 }
 
 #[cfg(test)]
 mod tests {
     use num::Rational64;
 
-    use super::compare_tensors;
-    use super::verify_equality_with_options;
+    use super::equal_circuit_tensor;
+    use super::equal_circuit_with_options;
     use crate::circuit::Circuit;
 
     /// Inspired by `BothCircuitsEmptyZXChecker` found in `test_equality.cpp` from mqt-qcec
@@ -70,8 +90,8 @@ mod tests {
         let c2 = Circuit::new(1);
 
         // c1 and c2 are equal
-        assert!(compare_tensors(&c1, &c2));
-        assert!(verify_equality_with_options(&c1, &c2, false).unwrap());
+        assert!(equal_circuit_tensor(&c1, &c2));
+        assert!(equal_circuit_with_options(&c1, &c2, false).unwrap());
     }
 
     /// Inspired by `GlobalPhase` found in `test_equality.cpp` from mqt-qcec
@@ -90,10 +110,10 @@ mod tests {
         c2.add_gate("x", vec![0]);
 
         // c1 and c2 are equal up to global phase
-        assert!(verify_equality_with_options(&c1, &c2, true).unwrap());
+        assert!(equal_circuit_with_options(&c1, &c2, true).unwrap());
         // c1 and c2 are unequal
-        assert!(!compare_tensors(&c1, &c2));
-        assert!(!verify_equality_with_options(&c1, &c2, false).unwrap());
+        assert!(!equal_circuit_tensor(&c1, &c2));
+        assert!(!equal_circuit_with_options(&c1, &c2, false).unwrap());
     }
 
     /// Inspired by `CloseButNotEqualConstruction` found in `test_equality.cpp` from mqt-qcec
@@ -109,9 +129,9 @@ mod tests {
         c2.add_gate_with_phase("rz", vec![0], Rational64::new(1, 1024));
 
         // c1 and c2 are unequal
-        assert!(!compare_tensors(&c1, &c2));
+        assert!(!equal_circuit_tensor(&c1, &c2));
         // c1 and c2 are not verifiably unequal with a simplification-based approach
-        assert!(verify_equality_with_options(&c1, &c2, true).is_none());
+        assert!(equal_circuit_with_options(&c1, &c2, true).is_none());
     }
 
     /// Inspired by `SimulationMoreThan64Qubits` found in `test_equality.cpp` from mqt-qcec
@@ -127,6 +147,6 @@ mod tests {
         // comparing the tensors of c1 and c2 is infeasible due to high number of qubits
 
         // c1 and c2 are verifiably equal
-        assert!(verify_equality_with_options(&c1, &c2, false).unwrap());
+        assert!(equal_circuit_with_options(&c1, &c2, false).unwrap());
     }
 }

--- a/quizx/src/equality.rs
+++ b/quizx/src/equality.rs
@@ -149,4 +149,20 @@ mod tests {
         // c1 and c2 are verifiably equal
         assert!(equal_circuit_with_options(&c1, &c2, false).unwrap());
     }
+
+    #[test]
+    fn cx_with_ancilla_as_x() {
+        let mut c1 = Circuit::new(1);
+        c1.add_gate("x", vec![0]);
+
+        let mut c2 = Circuit::new(2);
+        c2.add_gate("init_anc", vec![1]); // initiualize ancilla: |0⟩
+        c2.add_gate("x", vec![1]); // flip ancilla: |1⟩
+        c2.add_gate("cx", vec![1, 0]); // CX controlling for ancilla now behaves like X
+        c2.add_gate("x", vec![1]); // flip ancilla back: |0⟩ (otherwise the tensor zeros out!)
+        c2.add_gate("post_sel", vec![1]); // remove ancilla
+
+        assert!(equal_circuit_tensor(&c1, &c2));
+        assert!(equal_circuit_with_options(&c1, &c2, true).unwrap());
+    }
 }


### PR DESCRIPTION
- Only compares the graph tensors instead of the circuit tensors as a temporary workaround for: #135
- Equality checker now compares the number of input and output qubits separately instead of just the total number of qubits. (This is a step towards supporting circuits with [ancillae](https://github.com/zxcalc/quizx/issues/111#issuecomment-2889750454).)

BREAKING CHANGE: Introduced a consistent naming convention for equality related methods.