### PR TITLE
feat: converting Clifford circuits to graphs has the option to maintain AP form

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
           toolchain: 'stable'
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
+      - name: Build QuiZX binary with no features
+        run: cargo build --verbose --workspace --no-default-features --bin quizx
       - name: Build with no features
         run: cargo test --verbose --workspace --no-default-features --no-run -p quizx
       - name: Tests with no features
@@ -143,6 +145,8 @@ jobs:
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Build QuiZX binary with all features
+        run: cargo build --verbose --all-features --bin quizx
       - name: Build with all features
         run: cargo test --verbose --all-features --no-run -p quizx
       - name: Tests with all features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
 
 [[package]]
 name = "approx"
@@ -39,6 +83,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -73,6 +133,17 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -126,6 +197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -134,8 +206,22 @@ version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -143,6 +229,12 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "criterion"
@@ -236,6 +328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +353,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -282,6 +386,15 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -457,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +747,12 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num"
@@ -843,6 +968,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,12 +1085,15 @@ name = "quizx"
 version = "0.2.0"
 dependencies = [
  "approx",
+ "assert_cmd",
+ "clap",
  "criterion",
  "derive_more",
  "itertools 0.13.0",
  "ndarray",
  "num",
  "openqasm",
+ "predicates",
  "rand",
  "rayon",
  "regex",
@@ -1227,6 +1385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1428,12 @@ dependencies = [
  "rustversion",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1338,6 +1508,21 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/quizx/Cargo.toml
+++ b/quizx/Cargo.toml
@@ -25,10 +25,13 @@ rstest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 derive_more = { workspace = true, features = ["display", "error", "from"] }
+clap = { version = "4.5.38", features = ["cargo", "derive"] }
 
 [dev-dependencies]
 rstest = { workspace = true }
 criterion = { version = "0.6.0", features = ["html_reports"] }
+assert_cmd = "2.0.17"
+predicates = "3.1.3"
 
 [[bench]]
 name = "simplifier"

--- a/quizx/examples/surface_code.rs
+++ b/quizx/examples/surface_code.rs
@@ -8,8 +8,8 @@ use quizx::simplify::interior_clifford_simp;
 use quizx::{graph::*, vec_graph::Graph};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let distance = 50;
-    let rounds = 50;
+    let distance = 60;
+    let rounds = 60;
     let time = Instant::now();
     println!(
         "Building surface code circuit with distance {} and {} rounds...",
@@ -20,10 +20,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .rounds(rounds)
         .build();
     println!("Done in {:?}", time.elapsed());
+    println!("Surface code circuit has {} gates", c.num_gates());
 
     let time = Instant::now();
     println!("Converting to graph...");
-    let mut g: Graph = c.to_graph_with_options(false, false);
+    let mut g: Graph = c.to_graph_with_options(true, false);
     println!("Done in {:?}", time.elapsed());
 
     println!("Initial ZX diagram has {} vertices", g.num_vertices());

--- a/quizx/src/basic_rules.rs
+++ b/quizx/src/basic_rules.rs
@@ -836,7 +836,7 @@ pub fn remove_duplicate_unchecked(g: &mut impl GraphLike, v0: V, v1: V) {
 
     // TODO: check this gives the correct scalar
     let d = g.degree(v0) as i32;
-    g.scalar_mut().mul_sqrt2_pow(d - 2);
+    g.scalar_mut().mul_sqrt2_pow(-d);
     remove_single_unchecked(g, v0);
 }
 

--- a/quizx/src/basic_rules.rs
+++ b/quizx/src/basic_rules.rs
@@ -428,7 +428,7 @@ pub fn pivot_unchecked(g: &mut impl GraphLike, v0: V, v1: V) {
 
 checked_rule2!(check_pivot, pivot_unchecked, pivot);
 
-/// Insert an identity spider so v is no longer adjancent to boundary b
+/// Insert an identity spider so v is no longer adjacent to boundary b
 ///
 /// If b is not a boundary, this is a noop. The new vertex will be connected
 /// to v by a Hadamard edge.
@@ -1272,6 +1272,41 @@ mod tests {
         pi_copy(&mut g, vs[1]);
         assert_eq!(g.to_tensorf(), h.to_tensorf());
         pi_copy(&mut g, vs[4]);
+        assert_eq!(g.to_tensorf(), h.to_tensorf());
+    }
+
+    #[test]
+    fn remove_duplicate1() {
+        let mut g = Graph::new();
+
+        let b0 = g.add_vertex(VType::B);
+        let b1 = g.add_vertex(VType::B);
+        let b2 = g.add_vertex(VType::B);
+
+        let n0 = g.add_vertex(VType::Z);
+        let n1 = g.add_vertex(VType::Z);
+        let n2 = g.add_vertex(VType::Z);
+
+        let v0 = g.add_vertex_with_phase(VType::Z, Rational64::new(1, 4));
+        let v1 = g.add_vertex_with_phase(VType::Z, 1);
+
+        g.add_edge(b0, n0);
+        g.add_edge(b1, n1);
+        g.add_edge(b2, n2);
+
+        g.add_edge_with_type(n0, v0, EType::H);
+        g.add_edge_with_type(n1, v0, EType::H);
+        g.add_edge_with_type(n2, v0, EType::H);
+
+        g.add_edge_with_type(n0, v1, EType::H);
+        g.add_edge_with_type(n1, v1, EType::H);
+        g.add_edge_with_type(n2, v1, EType::H);
+
+        g.set_outputs(vec![b0, b1, b2]);
+
+        let h = g.clone();
+
+        assert!(remove_duplicate(&mut g, v0, v1));
         assert_eq!(g.to_tensorf(), h.to_tensorf());
     }
 }

--- a/quizx/src/bin/quizx.rs
+++ b/quizx/src/bin/quizx.rs
@@ -1,0 +1,11 @@
+use clap::Parser;
+use quizx::cli::Cli;
+
+fn main() {
+    let cli = Cli::parse();
+    let result = cli.run();
+    if let Err(e) = result {
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
+}

--- a/quizx/src/circuit.rs
+++ b/quizx/src/circuit.rs
@@ -703,7 +703,11 @@ mod tests {
 
     #[test]
     fn tograph_simplify() {
-        let c = Circuit::surface_code().distance(2).rounds(1).build();
+        let c = Circuit::random()
+            .qubits(4)
+            .depth(20)
+            .with_cliffords()
+            .build();
         let g1 = c.to_graph::<Graph>();
         let g2 = c.to_graph_with_options::<Graph>(true, false);
         assert_eq!(g1.to_tensorf(), g2.to_tensorf());

--- a/quizx/src/circuit.rs
+++ b/quizx/src/circuit.rs
@@ -700,4 +700,12 @@ mod tests {
         let g: Graph = c.to_graph_with_options(false, true);
         assert_eq!(c.to_tensorf(), g.to_tensorf());
     }
+
+    #[test]
+    fn tograph_simplify() {
+        let c = Circuit::surface_code().distance(2).rounds(1).build();
+        let g1 = c.to_graph::<Graph>();
+        let g2 = c.to_graph_with_options::<Graph>(true, false);
+        assert_eq!(g1.to_tensorf(), g2.to_tensorf());
+    }
 }

--- a/quizx/src/cli.rs
+++ b/quizx/src/cli.rs
@@ -1,0 +1,40 @@
+//! The QuiZX command line interface.
+
+use clap::{crate_version, Parser};
+
+pub mod opt;
+pub mod sim;
+
+/// CLI arguments.
+#[derive(Parser, Debug)]
+#[clap(version = crate_version!(), long_about = None)]
+#[clap(about = "QuiZX command line interface")]
+pub enum Cli {
+    /// Run the circuit optimizer.
+    Opt(opt::OptArgs),
+    /// Run the circuit simulator.
+    Sim(sim::SimArgs),
+}
+
+/// Error type for the CLI.
+#[derive(Debug, derive_more::Display, derive_more::From)]
+pub enum CliError {
+    /// Error reading or writing files.
+    #[display("IO error: {_0}")]
+    IO(std::io::Error),
+    /// Error parsing a QASM file.
+    #[display("Error parsing input circuit: {_0}")]
+    CircuitParse(String),
+    /// Provided bit/Pauli string has the wrong length
+    #[display("Circuit has {_0} qubits, but the provided {_2} string has length {_1}")]
+    StringWrongLen(usize, usize, String),
+}
+
+impl Cli {
+    pub fn run(self) -> Result<(), CliError> {
+        match self {
+            Cli::Opt(args) => args.run(),
+            Cli::Sim(args) => args.run(),
+        }
+    }
+}

--- a/quizx/src/cli/opt.rs
+++ b/quizx/src/cli/opt.rs
@@ -1,0 +1,143 @@
+//! The `opt` CLI subcommand.
+
+use clap::{Args, Parser};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::circuit::Circuit;
+use crate::extract::ToCircuit;
+use crate::simplify;
+use crate::vec_graph::Graph;
+
+use super::CliError;
+
+/// Run the circuit optimizer.
+#[derive(Parser, Debug)]
+pub struct OptArgs {
+    /// QASM file to optimize.
+    input: PathBuf,
+
+    /// Output to a file instead of printing the result.
+    #[arg(long, short)]
+    out: Option<PathBuf>,
+
+    /// Switch to select the optimization method. Defaults to `--full`.
+    #[command(flatten)]
+    method: Option<OptMethod>,
+}
+
+impl OptArgs {
+    /// Run the `opt` command using the provided arguments.
+    pub fn run(self) -> Result<(), CliError> {
+        let circ = Circuit::from_file(self.input.to_str().unwrap())?;
+        let mut g = circ.to_graph();
+        self.method.unwrap_or_default().simp(&mut g);
+        let qasm = g
+            .to_circuit()
+            .expect("Extraction should succeed since we start from a circuit")
+            .to_qasm();
+        if let Some(out_path) = self.out {
+            fs::write(out_path, qasm)?;
+        } else {
+            println!("{qasm}");
+        }
+        Ok(())
+    }
+}
+
+/// Optimization method.
+#[derive(Args, Debug)]
+#[group(multiple = false)]
+// Ideally, this should be an enum. Unfortunately, clap doesn't support enum arg
+// groups yet, so we have to use a struct where only one field is allowed to be
+// set to `true`. See https://github.com/clap-rs/clap/issues/2621.
+pub struct OptMethod {
+    /// Optimize using the `full_simp` method (default).
+    #[arg(long)]
+    full: bool,
+
+    /// Optimize using the `flow_simp` method.
+    #[arg(long)]
+    flow: bool,
+
+    /// Optimize using the `clifford_simp` method.
+    #[arg(long)]
+    clifford: bool,
+}
+
+impl Default for OptMethod {
+    fn default() -> Self {
+        OptMethod {
+            full: true,
+            flow: false,
+            clifford: false,
+        }
+    }
+}
+
+impl OptMethod {
+    fn simp(&self, g: &mut Graph) {
+        if self.full {
+            simplify::full_simp(g);
+        } else if self.flow {
+            simplify::flow_simp(g);
+        } else if self.clifford {
+            simplify::clifford_simp(g);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use assert_cmd::Command;
+    use predicates::str::contains;
+    use rstest::{fixture, rstest};
+
+    const CIRC: &str = "../circuits/small/mod5_4.qasm";
+
+    #[fixture]
+    fn cmd() -> Command {
+        let mut cmd = Command::cargo_bin("quizx").unwrap();
+        cmd.arg("opt");
+        cmd
+    }
+
+    #[rstest]
+    fn default(mut cmd: Command) {
+        cmd.arg(CIRC).assert().success();
+    }
+
+    #[rstest]
+    fn full(mut cmd: Command) {
+        cmd.arg(CIRC).arg("--full").assert().success();
+    }
+
+    #[rstest]
+    fn flow(mut cmd: Command) {
+        cmd.arg(CIRC).arg("--flow").assert().success();
+    }
+
+    #[rstest]
+    fn clifford(mut cmd: Command) {
+        cmd.arg(CIRC).arg("--clifford").assert().success();
+    }
+
+    #[rstest]
+    fn doesnt_exist(mut cmd: Command) {
+        cmd.arg("blah")
+            .assert()
+            .failure()
+            .stderr(contains("Error parsing input circuit: can't read file"));
+    }
+
+    #[rstest]
+    fn multiple_methods(mut cmd: Command) {
+        cmd.arg("--full")
+            .arg("--clifford")
+            .assert()
+            .failure()
+            .stderr(contains(
+                "the argument '--full' cannot be used with '--clifford'",
+            ));
+    }
+}

--- a/quizx/src/cli/sim.rs
+++ b/quizx/src/cli/sim.rs
@@ -1,0 +1,540 @@
+//! The `sim` CLI subcommand.
+
+use clap::{Args, Parser};
+use itertools::Itertools;
+use num::rational::Ratio;
+use num::Zero;
+use rand::{thread_rng, Rng};
+use std::error::Error;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::circuit::Circuit;
+use crate::decompose::Decomposer;
+use crate::fscalar::FScalar;
+use crate::graph::{BasisElem, GraphLike, VType};
+use crate::simplify;
+use crate::vec_graph::Graph;
+
+use super::CliError;
+
+/// Run the circuit simulator.
+#[derive(Parser, Debug)]
+pub struct SimArgs {
+    /// QASM file to simulate.
+    input: PathBuf,
+
+    /// Output to a file instead of printing the results.
+    #[arg(long, short)]
+    out: Option<PathBuf>,
+
+    /// Switch to select the decomposition method. Defaults to `--cats`.
+    #[command(flatten)]
+    method: Option<SimMethod>,
+
+    /// Switch to select the simulation task. Defaults to `--shots 1`.
+    #[command(flatten)]
+    task: Option<SimTask>,
+
+    /// Distribute computation across available CPU cores up to the given depth.
+    #[arg(long, short)]
+    parallel: Option<usize>,
+}
+
+impl SimArgs {
+    /// Run the `sim` command using the provided arguments.
+    pub fn run(self) -> Result<(), CliError> {
+        let circ = Circuit::from_file(self.input.to_str().unwrap())?;
+        let mut d = Decomposer::empty();
+        self.method.unwrap_or_default().configure_decomposer(&mut d);
+        let result = self
+            .task
+            .unwrap_or_default()
+            .run(&circ, &mut d, self.parallel)?;
+
+        if let Some(out_path) = self.out {
+            fs::write(out_path, result)?;
+        } else {
+            println!("{result}");
+        }
+        Ok(())
+    }
+}
+
+/// Simulation methods.
+#[derive(Args, Debug)]
+#[group(multiple = false)]
+// Ideally, this should be an enum. Unfortunately, clap doesn't support enum arg
+// groups yet, so we have to use a struct where only one field is allowed to be
+// set to `true`. See https://github.com/clap-rs/clap/issues/2621.
+pub struct SimMethod {
+    /// Use the cat state decomposition strategy (default).
+    #[arg(long)]
+    cats: bool,
+
+    /// Use the BSS decomposition strategy.
+    #[arg(long)]
+    bss: bool,
+}
+
+impl Default for SimMethod {
+    fn default() -> Self {
+        SimMethod {
+            bss: false,
+            cats: true,
+        }
+    }
+}
+
+impl SimMethod {
+    fn configure_decomposer(&self, decomposer: &mut Decomposer<Graph>) {
+        decomposer.with_full_simp();
+        decomposer.use_cats(self.cats);
+    }
+}
+
+/// Simulation tasks.
+#[derive(Args, Debug)]
+#[group(multiple = false)]
+// Ideally, this should be an enum. Unfortunately, clap doesn't support enum arg
+// groups yet, so we have to use a struct where only one field is allowed to be
+// set to `Some`. See https://github.com/clap-rs/clap/issues/2621.
+pub struct SimTask {
+    /// Sample from the circuit for a given number of shots.
+    #[arg(long, short)]
+    shots: Option<usize>,
+
+    /// Compute an amplitude.
+    #[arg(long = "amplitude", short = 'a', value_parser = parse_bit_string)]
+    bit_string: Option<BitString>,
+
+    /// Compute an expectation value.
+    #[arg(long = "expval", short = 'e', value_parser = parse_pauli_string)]
+    pauli_string: Option<PauliString>,
+}
+
+impl Default for SimTask {
+    fn default() -> Self {
+        SimTask {
+            shots: Some(1),
+            bit_string: None,
+            pauli_string: None,
+        }
+    }
+}
+
+impl SimTask {
+    pub fn run(
+        &self,
+        circ: &Circuit,
+        decomposer: &mut Decomposer<Graph>,
+        parallel: Option<usize>,
+    ) -> Result<String, CliError> {
+        if let Some(shots) = self.shots {
+            Ok((0..shots)
+                .map(|_| sample(circ, decomposer, parallel))
+                .join("\n")
+                .to_string())
+        } else if let Some(ref bit_str) = self.bit_string {
+            Ok(format!("{}", amplitude(circ, decomposer, bit_str, parallel)?).to_string())
+        } else if let Some(ref pauli_str) = self.pauli_string {
+            Ok(format!(
+                "{}",
+                expectation_value(circ, decomposer, pauli_str, parallel)?
+            )
+            .to_string())
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+// Need to wrap the vector into a type alias, otherwise clap tries to do some
+// varag parsing magic that breaks our custom parser below.
+type BitString = Vec<bool>;
+
+#[derive(Debug, derive_more::Display)]
+#[display("'{_0}' is not a valid bit. Expected sequence of 0s and 1s.")]
+struct BitStringParseError(char);
+
+impl Error for BitStringParseError {}
+
+fn parse_bit_string(s: &str) -> Result<BitString, BitStringParseError> {
+    s.chars()
+        .map(|c| match c.to_ascii_uppercase() {
+            '0' => Ok(false),
+            '1' => Ok(true),
+            _ => Err(BitStringParseError(c)),
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Pauli {
+    I,
+    X,
+    Y,
+    Z,
+}
+
+// Need to wrap the vector into a type alias, otherwise clap tries to do some
+// varag parsing magic that breaks our custom parser below.
+type PauliString = Vec<Pauli>;
+
+#[derive(Debug, derive_more::Display)]
+#[display("'{_0}' is not a Pauli. Expected one of 'I', 'X', 'Y', 'Z'.")]
+struct PauliStringParseError(char);
+
+impl Error for PauliStringParseError {}
+
+fn parse_pauli_string(s: &str) -> Result<PauliString, PauliStringParseError> {
+    s.chars()
+        .map(|c| match c.to_ascii_uppercase() {
+            'I' => Ok(Pauli::I),
+            'X' => Ok(Pauli::X),
+            'Y' => Ok(Pauli::Y),
+            'Z' => Ok(Pauli::Z),
+            _ => Err(PauliStringParseError(c)),
+        })
+        .collect()
+}
+
+/// Sample from a circuit by computing marginals via doubling of the diagram.
+fn sample(circ: &Circuit, decomposer: &mut Decomposer<Graph>, parallel: Option<usize>) -> String {
+    let qs = circ.num_qubits();
+    let mut xs: Vec<bool> = vec![];
+    let mut rng = thread_rng();
+    for _ in 0..qs {
+        let mut g: Graph = circ.to_graph();
+        g.plug_inputs(&vec![BasisElem::Z0; qs]);
+        for x in &xs {
+            // Plug removes the output, so we have to keep using index 0
+            g.plug_output(0, if *x { BasisElem::Z1 } else { BasisElem::Z0 });
+        }
+        g.plug_output(0, BasisElem::Z1);
+        g.plug(&g.to_adjoint());
+
+        let scalar = decomp_graph(g, decomposer, parallel);
+        xs.push(rng.gen_bool(scalar.complex_value().re));
+    }
+    xs.iter().map(|x| if *x { '1' } else { '0' }).join("")
+}
+
+/// Compute an amplitude.
+fn amplitude(
+    circ: &Circuit,
+    decomposer: &mut Decomposer<Graph>,
+    bit_str: &BitString,
+    parallel: Option<usize>,
+) -> Result<f64, CliError> {
+    let qs = circ.num_qubits();
+    let bit_str = match bit_str.as_slice() {
+        [b] => &vec![*b; qs],
+        bs if bs.len() == qs => bit_str,
+        _ => {
+            return Err(CliError::StringWrongLen(
+                qs,
+                bit_str.len(),
+                "bit".to_string(),
+            ))
+        }
+    };
+
+    let mut g: Graph = circ.to_graph();
+    g.plug_inputs(&vec![BasisElem::Z0; qs]);
+    g.plug_outputs(
+        &bit_str
+            .iter()
+            .map(|x| if *x { BasisElem::Z1 } else { BasisElem::Z0 })
+            .collect_vec(),
+    );
+
+    let scalar = decomp_graph(g, decomposer, parallel);
+    let amp = scalar * scalar.conj();
+    Ok(amp.complex_value().re)
+}
+
+/// Computes an expectation value by doubling the diagram.
+fn expectation_value(
+    circ: &Circuit,
+    decomposer: &mut Decomposer<Graph>,
+    pauli_str: &PauliString,
+    parallel: Option<usize>,
+) -> Result<f64, CliError> {
+    let qs = circ.num_qubits();
+    let pauli_str = match pauli_str.as_slice() {
+        [p] => &vec![*p; qs],
+        ps if ps.len() == qs => pauli_str,
+        _ => {
+            return Err(CliError::StringWrongLen(
+                qs,
+                pauli_str.len(),
+                "Pauli".to_string(),
+            ))
+        }
+    };
+
+    let mut g: Graph = circ.to_graph();
+    g.plug_inputs(&vec![BasisElem::Z0; qs]);
+    let g_adj = g.to_adjoint();
+    for (i, p) in pauli_str.iter().enumerate() {
+        let b = g.outputs()[i];
+        let [(v, _)] = g.incident_edge_vec(b).try_into().unwrap();
+        match p {
+            Pauli::I => {}
+            Pauli::X => {
+                let x = g.add_vertex_with_phase(VType::X, 1);
+                g.remove_edge(v, b);
+                g.add_edge(v, x);
+                g.add_edge(x, b);
+            }
+            Pauli::Y => {
+                let x = g.add_vertex_with_phase(VType::X, 1);
+                let z = g.add_vertex_with_phase(VType::Z, 1);
+                g.remove_edge(v, b);
+                g.add_edge(v, z);
+                g.add_edge(z, x);
+                g.add_edge(x, b);
+                g.scalar_mut().mul_phase(Ratio::new(1, 2));
+            }
+            Pauli::Z => {
+                let z = g.add_vertex_with_phase(VType::Z, 1);
+                g.remove_edge(v, b);
+                g.add_edge(v, z);
+                g.add_edge(z, b);
+            }
+        }
+    }
+    g.plug(&g_adj);
+
+    let scalar = decomp_graph(g, decomposer, parallel);
+    Ok(scalar.complex_value().re)
+}
+
+/// Run the provided decomposer on a graph.
+fn decomp_graph(
+    mut g: Graph,
+    decomposer: &mut Decomposer<Graph>,
+    parallel: Option<usize>,
+) -> FScalar {
+    simplify::full_simp(&mut g);
+    decomposer.stack.push_back((0, g));
+    decomposer.scalar = FScalar::zero();
+    if let Some(depth) = parallel {
+        decomposer.clone().decomp_parallel(depth).scalar
+    } else {
+        decomposer.decomp_all().scalar
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use assert_cmd::Command;
+    use predicates::{ord::eq, str::contains};
+    use rstest::{fixture, rstest};
+
+    const CIRC: &str = "../circuits/small/mod5_4.qasm";
+    const SAMPLE: &str = "00001\n";
+
+    #[fixture]
+    fn cmd() -> Command {
+        let mut cmd = Command::cargo_bin("quizx").unwrap();
+        cmd.arg("sim");
+        cmd
+    }
+
+    #[rstest]
+    fn default(mut cmd: Command) {
+        cmd.arg(CIRC).assert().success().stdout(eq(SAMPLE));
+    }
+
+    #[rstest]
+    fn samples(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--shots")
+            .arg("2")
+            .assert()
+            .success()
+            .stdout(eq([SAMPLE, SAMPLE].join("")));
+    }
+
+    #[rstest]
+    fn amplitude_single(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--amplitude")
+            .arg("0")
+            .assert()
+            .success()
+            .stdout(eq("0\n"));
+    }
+
+    #[rstest]
+    fn amplitude_long(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--amplitude")
+            .arg("00001")
+            .assert()
+            .success()
+            .stdout(eq("1\n"));
+    }
+
+    #[rstest]
+    fn expectation_single(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--expval")
+            .arg("Z")
+            .assert()
+            .success()
+            .stdout(eq("-1\n"));
+    }
+
+    #[rstest]
+    fn expectation_explicit(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--expval")
+            .arg("IXYZZ")
+            .assert()
+            .success()
+            .stdout(eq("0\n"));
+    }
+
+    #[rstest]
+    fn expectation_lower(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--expval")
+            .arg("ixzyy")
+            .assert()
+            .success()
+            .stdout(eq("0\n"));
+    }
+
+    #[rstest]
+    fn bss(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--bss")
+            .assert()
+            .success()
+            .stdout(eq(SAMPLE));
+    }
+
+    #[rstest]
+    fn cats(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--cats")
+            .assert()
+            .success()
+            .stdout(eq(SAMPLE));
+    }
+
+    #[rstest]
+    fn parallel_sample(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--parallel")
+            .arg("2")
+            .assert()
+            .success()
+            .stdout(eq(SAMPLE));
+    }
+
+    #[rstest]
+    fn parallel_amplitude(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--expval")
+            .arg("z")
+            .arg("--parallel")
+            .arg("2")
+            .assert()
+            .success()
+            .stdout(eq("-1\n"));
+    }
+
+    #[rstest]
+    fn parallel_expectation(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--expval")
+            .arg("z")
+            .arg("--parallel")
+            .arg("2")
+            .assert()
+            .success()
+            .stdout(eq("-1\n"));
+    }
+
+    #[rstest]
+    fn doesnt_exist(mut cmd: Command) {
+        cmd.arg("blah")
+            .assert()
+            .failure()
+            .stderr(contains("Error parsing input circuit: can't read file"));
+    }
+
+    #[rstest]
+    fn multiple_methods(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--bss")
+            .arg("--cats")
+            .assert()
+            .failure()
+            .stderr(contains(
+                "the argument '--bss' cannot be used with '--cats'",
+            ));
+    }
+
+    #[rstest]
+    fn multiple_tasks(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--shots")
+            .arg("2")
+            .arg("--expval")
+            .arg("Z")
+            .assert()
+            .failure()
+            .stderr(contains(
+                "the argument '--shots <SHOTS>' cannot be used with '--expval <PAULI_STRING>'",
+            ));
+    }
+
+    #[rstest]
+    fn bad_bit(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--amplitude")
+            .arg("00210")
+            .assert()
+            .failure()
+            .stderr(contains("invalid value '00210' for '--amplitude <BIT_STRING>': '2' is not a valid bit. Expected sequence of 0s and 1s."));
+    }
+
+    #[rstest]
+    fn bit_string_len(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--amplitude")
+            .arg("010")
+            .assert()
+            .failure()
+            .stderr(contains(
+                "Circuit has 5 qubits, but the provided bit string has length 3",
+            ));
+    }
+
+    #[rstest]
+    fn bad_pauli(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--expval")
+            .arg("ZXYAI")
+            .assert()
+            .failure()
+            .stderr(contains("invalid value 'ZXYAI' for '--expval <PAULI_STRING>': 'A' is not a Pauli. Expected one of 'I', 'X', 'Y', 'Z'."));
+    }
+
+    #[rstest]
+    fn pauli_string_len(mut cmd: Command) {
+        cmd.arg(CIRC)
+            .arg("--expval")
+            .arg("ZZZ")
+            .assert()
+            .failure()
+            .stderr(contains(
+                "Circuit has 5 qubits, but the provided Pauli string has length 3",
+            ));
+    }
+}

--- a/quizx/src/lib.rs
+++ b/quizx/src/lib.rs
@@ -59,6 +59,7 @@
 pub mod annealer;
 pub mod basic_rules;
 pub mod circuit;
+pub mod cli;
 pub mod decompose;
 pub mod equality;
 pub mod extract;

--- a/quizx/src/simplify.rs
+++ b/quizx/src/simplify.rs
@@ -206,6 +206,10 @@ pub fn local_ap_simp(g: &mut impl GraphLike, vs: impl IntoIterator<Item = V>) {
     }
 
     for v in simp_v {
+        if !g.contains_vertex(v) {
+            continue;
+        }
+
         for u in g.neighbor_vec(v) {
             if spider_fusion(g, v, u)
                 || local_comp(g, u)
@@ -213,6 +217,15 @@ pub fn local_ap_simp(g: &mut impl GraphLike, vs: impl IntoIterator<Item = V>) {
                 || h_boundary_pivot(g, v, u)
             {
                 break;
+            }
+        }
+
+        if g.contains_vertex(v) {
+            let u_opt = g.neighbors(v).next();
+            if let Some(u) = u_opt {
+                g.neighbor_vec(u)
+                    .iter()
+                    .any(|u1| remove_duplicate(g, v, *u1));
             }
         }
     }

--- a/quizx/src/tensor.rs
+++ b/quizx/src/tensor.rs
@@ -315,6 +315,7 @@ impl<G: GraphLike + Clone> ToTensor for G {
         // H-boxes are not implemented yet
         for v in g.vertices() {
             let t = g.vertex_type(v);
+
             if t != VType::B && t != VType::Z {
                 panic!("Vertex type currently unsupported: {t:?}");
             }


### PR DESCRIPTION
Using a flag in `Circuit::to_graph_with_options`, graphs can be kept in AP form, removing redundant stabilizer projectors as it progresses. For big syndrome extraction circuits, this gives a huge boost in performance vs using GSLC or simplifying all at once.