### PR TITLE
feat!: Add spider-cutting decomposition

### DIFF
--- a/quizx/src/decompose.rs
+++ b/quizx/src/decompose.rs
@@ -765,12 +765,15 @@ impl<G: GraphLike> Decomposer<G> {
                         let components = g.component_vertices();
                         if components.len() > 1 {
                             // println!("Number of components {}", components.len());
-                            let subgraphs: Vec<G> = components
+                            let mut subgraphs: Vec<G> = components
                                 .into_iter()
                                 .map(|component| {
                                     g.subgraph_from_vertices(component.into_iter().collect())
                                 })
                                 .collect();
+                            if subgraphs.len() > 0 {
+                                *subgraphs[0].scalar_mut() = g.scalar().clone();
+                            }
                             let terms_vec: Vec<ComputationNode<G>> = if parallel {
                                 subgraphs
                                     .into_par_iter()

--- a/quizx/src/decompose.rs
+++ b/quizx/src/decompose.rs
@@ -124,6 +124,7 @@ pub enum Decomp {
     BssDecomp(Vec<usize>),
     SymDecomp(Vec<usize>),
     SingleDecomp(Vec<usize>),
+    SpiderCuttingDecomp(Vec<usize>),
 }
 use Decomp::*;
 
@@ -131,6 +132,7 @@ use Decomp::*;
 pub enum Driver {
     BssTOnly(bool),
     BssWithCats(bool),
+    SpiderCutting,
 }
 use Driver::*;
 
@@ -164,6 +166,13 @@ impl Driver {
                         TDecomp(ts)
                     }
                 }
+            }
+            SpiderCutting => {
+                let next_non_clifford = g
+                    .vertices()
+                    .find(|&v| !g.vertex_data(v).phase.is_clifford())
+                    .expect("The graph contains no non-Clifford spider");
+                SpiderCuttingDecomp(vec![next_non_clifford])
             }
         }
     }
@@ -494,6 +503,29 @@ fn apply_cat_decomp<G: GraphLike>(g: &G, verts: &[V]) -> Vec<G> {
     }
 }
 
+/// Perform graph cutting by removing a n-legged Z-spider and changing the phases of its neighbors.
+/// (equivalent to replacing with n one-legged X-spiders + simplification)
+/// See section 3 of https://arxiv.org/abs/2403.10964v2
+fn apply_spider_cutting_decomp<G: GraphLike>(g: &G, verts: &[V]) -> Vec<G> {
+    vec![cut_spider(g, verts, false), cut_spider(g, verts, true)]
+}
+
+fn cut_spider<G: GraphLike>(g: &G, verts: &[V], with_phase: bool) -> G {
+    let mut g = g.clone();
+    let v = verts[0];
+    let k = g.neighbors(v).count() as i32;
+    g.scalar_mut().mul_sqrt2_pow(-k);
+    if with_phase {
+        let alpha = g.vertex_data(v).phase;
+        g.scalar_mut().mul_phase(alpha);
+        for n in g.neighbor_vec(v) {
+            g.vertex_data_mut(n).phase += 1.into();
+        }
+    }
+    g.remove_vertex(v);
+    g
+}
+
 #[derive(Clone)]
 enum ComputationNode<G: GraphLike> {
     Graph(G),
@@ -817,7 +849,8 @@ impl<G: GraphLike> Decomposer<G> {
                         CatDecomp(vertices) => apply_cat_decomp(&g, &vertices),
                         BssDecomp(vertices) => apply_bss_decomp(&g, &vertices),
                         SymDecomp(vertices) => apply_sym_decomp(&g, &vertices),
-                        SingleDecomp(vertices) => apply_single_decomp(&g, &vertices),
+                        SingleDecomp(vertices) => apply_spider_cutting_decomp(&g, &vertices),
+                        SpiderCuttingDecomp(vertices) => apply_spider_cutting_decomp(&g, &vertices),
                     };
                     let terms_vec: Vec<ComputationNode<G>> = if parallel {
                         terms
@@ -866,6 +899,7 @@ impl<G: GraphLike> Decomposer<G> {
 mod tests {
     // use num::rational::Ratio;
 
+    use approx::abs_diff_eq;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
 
@@ -897,6 +931,24 @@ mod tests {
                 }
             }
         }
+        g
+    }
+
+    // Create a circuit with Z spiders with phase random multiple of pi/8,
+    // randomly connected by Hadamard edges and no external edges
+    fn create_non_t_graph(n: usize, seed: u64) -> Graph {
+        let mut g = Graph::new();
+        let mut rng = StdRng::seed_from_u64(seed);
+        for i in 0..n {
+            let phase = Rational64::new(rng.gen_range(0..8), 8);
+            let v = g.add_vertex_with_phase(VType::Z, phase);
+            for j in 0..i {
+                if rng.gen_bool(0.5) {
+                    g.add_edge_with_type(v, j, EType::H);
+                }
+            }
+        }
+
         g
     }
 
@@ -1053,6 +1105,24 @@ mod tests {
         assert_eq!(original_scalar, sum);
     }
 
+    #[test]
+    fn test_spider_cutting_decomp() {
+        for size in 2..8 {
+            for seed in [42, 5518] {
+                let g = create_non_t_graph(size, seed);
+                for v in g.vertices() {
+                    let original_scalar = g.to_tensorf()[[]];
+
+                    let sum_of_new_scalars: FScalar = apply_spider_cutting_decomp(&g, &[v])
+                        .iter()
+                        .map(|new_g| new_g.to_tensorf()[[]])
+                        .sum();
+                    _ = abs_diff_eq!(original_scalar, sum_of_new_scalars);
+                }
+            }
+        }
+    }
+
     // Test all configurations of the decomposer
     #[test]
     fn test_decomposer_all_configs() {
@@ -1063,6 +1133,7 @@ mod tests {
             BssTOnly(true),
             BssWithCats(false),
             BssWithCats(true),
+            SpiderCutting,
         ];
         let split_components = vec![false, true];
         let parallel_modes = vec![false, true];

--- a/quizx/src/decompose.rs
+++ b/quizx/src/decompose.rs
@@ -771,8 +771,8 @@ impl<G: GraphLike> Decomposer<G> {
                                     g.subgraph_from_vertices(component.into_iter().collect())
                                 })
                                 .collect();
-                            if subgraphs.len() > 0 {
-                                *subgraphs[0].scalar_mut() = g.scalar().clone();
+                            if !subgraphs.is_empty() {
+                                *subgraphs[0].scalar_mut() = *g.scalar();
                             }
                             let terms_vec: Vec<ComputationNode<G>> = if parallel {
                                 subgraphs


### PR DESCRIPTION
BREAKING CHANGE: Added enum variants `Driver::SpiderCutting` and `Decomp::SpiderCuttingDecomp`

closes #115 