### PR TITLE
test: add benchmarks

### DIFF
--- a/quizx/Cargo.toml
+++ b/quizx/Cargo.toml
@@ -34,5 +34,13 @@ assert_cmd = "2.0.17"
 predicates = "3.1.3"
 
 [[bench]]
+name = "basics"
+harness = false
+
+[[bench]]
 name = "simplifier"
+harness = false
+
+[[bench]]
+name = "decomposer"
 harness = false

--- a/quizx/benches/basics.rs
+++ b/quizx/benches/basics.rs
@@ -1,0 +1,51 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use quizx::circuit::Circuit;
+use quizx::graph::GraphLike;
+use quizx::vec_graph::Graph;
+
+fn get_test_files() -> Vec<String> {
+    vec![
+        // "../circuits/small/tof_3.qasm".to_string(),
+        // "../circuits/small/tof_5.qasm".to_string(),
+        "../circuits/small/tof_10.qasm".to_string(),
+    ]
+}
+
+fn benchmark_loading_saving_cloning(c: &mut Criterion) {
+    for file in get_test_files() {
+        let file_name = file.split('/').next_back().unwrap_or("unknown_file");
+        let qasm = std::fs::read_to_string(&file)
+            .unwrap_or_else(|_| panic!("Failed to read QASM file: {}", file));
+
+        c.bench_function(&format!("loading_saving_circuit_{}", file_name), |b| {
+            b.iter(|| {
+                let circuit = Circuit::from_qasm(&qasm).unwrap();
+                std::hint::black_box(circuit.to_qasm());
+            });
+        });
+
+        c.bench_function(&format!("converting_circuit_to_graph_{}", file_name), |b| {
+            b.iter_batched_ref(
+                || Circuit::from_qasm(&qasm).unwrap(),
+                |circuit| {
+                    let graph: Graph = circuit.to_graph();
+                    assert!(graph.num_vertices() > 0);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        c.bench_function(&format!("cloning_circuit_{}", file_name), |b| {
+            b.iter_batched_ref(
+                || Circuit::from_qasm(&qasm).unwrap(),
+                |circuit| {
+                    let _clone = circuit.clone();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, benchmark_loading_saving_cloning);
+criterion_main!(benches);

--- a/quizx/benches/basics.rs
+++ b/quizx/benches/basics.rs
@@ -15,7 +15,8 @@ fn benchmark_loading_saving_cloning(c: &mut Criterion) {
     for file in get_test_files() {
         let file_name = file.split('/').next_back().unwrap_or("unknown_file");
         let qasm = std::fs::read_to_string(&file)
-            .unwrap_or_else(|_| panic!("Failed to read QASM file: {}", file));
+            .unwrap_or_else(|_| panic!("Failed to read QASM file: {}", file))
+            .replace("\r\n", "\n");
 
         c.bench_function(&format!("loading_saving_circuit_{}", file_name), |b| {
             b.iter(|| {

--- a/quizx/benches/decomposer.rs
+++ b/quizx/benches/decomposer.rs
@@ -12,7 +12,8 @@ fn benchmark_graph_scalar(c: &mut Criterion) {
     for file in get_test_files() {
         let file_name = file.split('/').next_back().unwrap_or("unknown_file");
         let qasm = std::fs::read_to_string(&file)
-            .unwrap_or_else(|_| panic!("Failed to read QASM file: {}", file));
+            .unwrap_or_else(|_| panic!("Failed to read QASM file: {}", file))
+            .replace("\r\n", "\n");
         // Path to the graph file
         let circ = Circuit::from_qasm(&qasm).expect("Failed to create circuit from QASM");
         let vec_graph: VecGraph = circ.to_graph();

--- a/quizx/benches/decomposer.rs
+++ b/quizx/benches/decomposer.rs
@@ -1,0 +1,52 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use quizx::circuit::Circuit;
+use quizx::decompose::Decomposer;
+use quizx::hash_graph::Graph as HashGraph;
+use quizx::vec_graph::Graph as VecGraph;
+
+fn get_test_files() -> Vec<String> {
+    vec!["../circuits/small/barenco_tof_3.qasm".to_string()]
+}
+
+fn benchmark_graph_scalar(c: &mut Criterion) {
+    for file in get_test_files() {
+        let file_name = file.split('/').next_back().unwrap_or("unknown_file");
+        let qasm = std::fs::read_to_string(&file)
+            .unwrap_or_else(|_| panic!("Failed to read QASM file: {}", file));
+        // Path to the graph file
+        let circ = Circuit::from_qasm(&qasm).expect("Failed to create circuit from QASM");
+        let vec_graph: VecGraph = circ.to_graph();
+        let hash_graph: HashGraph = circ.to_graph();
+
+        // Benchmark the scalar evaluation
+        c.bench_function(&format!("evaluate_vec_graph_scalar_{}", file_name), |b| {
+            b.iter_batched_ref(
+                || vec_graph.clone(), // Clone the graph before timing
+                |g| {
+                    let mut decomposer = Decomposer::new(g);
+                    decomposer.decomp_all();
+                    let scalar = decomposer.scalar;
+                    std::hint::black_box(scalar); // Prevent optimization
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        // Benchmark the scalar evaluation
+        c.bench_function(&format!("evaluate_hash_graph_scalar_{}", file_name), |b| {
+            b.iter_batched_ref(
+                || hash_graph.clone(), // Clone the graph before timing
+                |g| {
+                    let mut decomposer = Decomposer::new(g);
+                    decomposer.decomp_all();
+                    let scalar = decomposer.scalar;
+                    std::hint::black_box(scalar); // Prevent optimization
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, benchmark_graph_scalar);
+criterion_main!(benches);

--- a/quizx/benches/simplifier.rs
+++ b/quizx/benches/simplifier.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use quizx::circuit::Circuit;
-use quizx::simplify::interior_clifford_simp;
+use quizx::simplify::{clifford_simp, flow_simp, full_simp, interior_clifford_simp};
 use quizx::vec_graph::*;
 
 fn simp_surface_code(c: &mut Criterion) {
@@ -17,12 +17,48 @@ fn simp_surface_code(c: &mut Criterion) {
     let mut group = c.benchmark_group("surface_code");
     group.sample_size(10); // 10 is the minimum, 100 is default
 
-    group.bench_function("simp_surface_code", |b| {
+    group.bench_function("surface_code_interior_clifford_simp", |b| {
         b.iter_batched_ref(
             || g.clone(), // clone the graph before timing
             |g1| {
                 // timed application of the simplifier
                 interior_clifford_simp(g1);
+            },
+            // use SmallInput for smaller graphs for less overhead
+            BatchSize::LargeInput,
+        )
+    });
+
+    group.bench_function("surface_code_clifford_simp", |b| {
+        b.iter_batched_ref(
+            || g.clone(), // clone the graph before timing
+            |g1| {
+                // timed application of the simplifier
+                clifford_simp(g1);
+            },
+            // use SmallInput for smaller graphs for less overhead
+            BatchSize::LargeInput,
+        )
+    });
+
+    group.bench_function("surface_code_full_simp", |b| {
+        b.iter_batched_ref(
+            || g.clone(), // clone the graph before timing
+            |g1| {
+                // timed application of the simplifier
+                full_simp(g1);
+            },
+            // use SmallInput for smaller graphs for less overhead
+            BatchSize::LargeInput,
+        )
+    });
+
+    group.bench_function("surface_code_flow_simp", |b| {
+        b.iter_batched_ref(
+            || g.clone(), // clone the graph before timing
+            |g1| {
+                // timed application of the simplifier
+                flow_simp(g1);
             },
             // use SmallInput for smaller graphs for less overhead
             BatchSize::LargeInput,


### PR DESCRIPTION
Closes #134 

There are 3 benchmark files, `basics.rs`, `simplifier.rs`, `decomposer.rs`. 

- [x] loading and saving circuits
- [x] converting circuits to graphs
- [x] performance of `clone`
- [x] the main simplification methods in [simplify.rs](https://github.com/zxcalc/quizx/blob/master/quizx/src/simplify.rs): `flow_simp`, `interior_clifford_simp`, `clifford_simp`, and `full_simp`
- [x] the [decomposer](https://github.com/zxcalc/quizx/blob/master/quizx/src/decompose.rs), used for classical simulation, a comparison between `VecGraph` and `HashGraph`.

the test files are specified in `get_test_files`, so we can add and remove qasm test files as we wish.